### PR TITLE
Cache gets can specify the latest desired version

### DIFF
--- a/lib/entity_cache/entity_cache.rb
+++ b/lib/entity_cache/entity_cache.rb
@@ -27,18 +27,21 @@ class EntityCache
     instance
   end
 
-  def get(id, include: nil)
-    logger.opt_trace "Reading cache (ID: #{id.inspect}, Include: #{include.inspect})"
+  def get(id, include: nil, latest_version: nil)
+    logger.opt_trace "Reading cache (ID: #{id.inspect}, Include: #{include.inspect}, LatestVersion: #{latest_version.inspect})"
 
     record = temporary_store.get id
     record ||= restore id
 
     if record.nil?
-      logger.opt_debug "Cache miss (ID: #{id.inspect})"
+      logger.opt_debug "Cache miss (ID: #{id.inspect}, LatestVersion: #{latest_version.inspect})"
+      return nil
+    elsif latest_version && record.version > latest_version
+      logger.opt_debug "Latest version precedes record; cache miss (ID: #{id.inspect}, LatestVersion: #{latest_version.inspect}, RecordVersion: #{record.version.inspect})"
       return nil
     end
 
-    logger.opt_debug "Cache hit (ID: #{id.inspect}, Entity Class: #{record.entity.class.name}, Version: #{record.version.inspect}, Time: #{record.time})"
+    logger.opt_debug "Cache hit (ID: #{id.inspect}, Entity Class: #{record.entity.class.name}, Version: #{record.version.inspect}, Time: #{record.time}, LatestVersion: #{latest_version.inspect})"
 
     record
   end

--- a/test/bench/get/latest_version_is_specified.rb
+++ b/test/bench/get/latest_version_is_specified.rb
@@ -1,0 +1,51 @@
+require_relative '../bench_init'
+
+context "Latest version is specified when retrieving a cache record" do
+  id = Controls::ID.get
+
+  cache = EntityCache.new
+
+  context "Entity is not cached" do
+    record = cache.get id
+
+    test "No record is returned" do
+      assert record.nil?
+    end
+  end
+
+  context "Cached entity version precedes specified latest version" do
+    control_record = EntityCache::Controls::Record.example version: 0
+
+    cache.temporary_store.put control_record
+
+    record = cache.get id, latest_version: 1
+
+    test "Record is returned" do
+      assert record == control_record
+    end
+  end
+
+  context "Cached entity version matches specified latest version" do
+    control_record = EntityCache::Controls::Record.example version: 1
+
+    cache.temporary_store.put control_record
+
+    record = cache.get id, latest_version: 1
+
+    test "Record is returned" do
+      assert record == control_record
+    end
+  end
+
+  context "Specified latest version precedes cached entity version" do
+    control_record = EntityCache::Controls::Record.example version: 1
+
+    cache.temporary_store.put control_record
+
+    record = cache.get id, latest_version: 0
+
+    test "No record is returned" do
+      assert record.nil?
+    end
+  end
+end


### PR DESCRIPTION
This augments the cache get operation by allowing the user to specify the latest version of the entity to be returned by the cache, e.g. 

``` ruby
cache.get some_id, latest_version: 111
```

In the above example, the cache will not return a cache record if the version on the record exceeds `111`.

This interface change will allow other caches to be built which can keep track of historic versions of entities, in addition to simplifying the the implementation of this PR to `event-store-entity-store`: https://github.com/eventide-project/event-store-entity-store/pull/3

I am not quite sure `latest_version` is the correct name for the parameter. It certainly can be construed in unintended ways. `max_version` has no ambiguity, but seems mechanical.
