### PR TITLE
Fix problem with Ruby 3.1.0's YAML parser

### DIFF
--- a/lib/entity_cache/controls/store/external/example.rb
+++ b/lib/entity_cache/controls/store/external/example.rb
@@ -18,7 +18,15 @@ class EntityCache
 
             text = File.read(path)
 
-            entity, version, time = YAML.load(text)
+            entity_data, version, time_iso8601 = YAML.load(text)
+
+            entity = Entity::Example.new(
+              entity_data[:id],
+              entity_data[:some_attr],
+              entity_data[:other_attr]
+            )
+
+            time = Clock.parse(time_iso8601)
 
             return entity, version, time
           end
@@ -26,7 +34,11 @@ class EntityCache
           def put(id, entity, version, time)
             path = path(id)
 
-            text = YAML.dump([entity, version, time])
+            entity_data = entity.to_h
+
+            time_iso8601 = Clock.iso8601(time)
+
+            text = YAML.dump([entity_data, version, time_iso8601])
 
             File.write(path, text)
           end

--- a/lib/entity_cache/controls/store/external/write.rb
+++ b/lib/entity_cache/controls/store/external/write.rb
@@ -6,10 +6,14 @@ class EntityCache
           def self.call
             subject = Subject.example
 
+            entity_data = Controls::Entity.example.to_h
+
+            persisted_time_iso8601 = Controls::Record.persisted_time.iso8601(5)
+
             text = YAML.dump([
-              Controls::Entity.example,
+              entity_data,
               Controls::Record.persisted_version,
-              Controls::Record.persisted_time
+              persisted_time_iso8601
             ])
 
             path = External.path(subject)


### PR DESCRIPTION
The current implementation's _control_ external store relies on YAML to serialize the control entity data, because, prior to Ruby 3.1.0, YAML could serialize _any_ object. However, Ruby 3.1.0's YAML seems to have new limitations on what it can (and cannot) serialize. This pull request changes the control external store to convert to and from raw data when converting to and from YAML, respectively.